### PR TITLE
feat: display version in Alfred UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,28 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          # Get the next version that semantic-release will create
+          NEXT_VERSION=$(npx semantic-release --dry-run | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' || echo '')
+          
+          if [ ! -z "$NEXT_VERSION" ]; then
+            # Create a temporary file with the version update
+            awk -v ver="$NEXT_VERSION" '
+              /<key>version<\/key>/ {
+                print $0
+                getline
+                sub(/>.*</, ">" ver "<")
+              }
+              { print }
+            ' info.plist > info.plist.tmp && mv info.plist.tmp info.plist
+            
+            # Commit the version update
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+            git add info.plist
+            git commit -m "chore: update version to $NEXT_VERSION [skip ci]"
+            git push
+          fi
+          
+          # Run the actual release
+          npx semantic-release

--- a/info.plist
+++ b/info.plist
@@ -56,6 +56,8 @@
     <false/>
     <key>name</key>
     <string>Tabman</string>
+    <key>version</key>
+    <string>1.0.1</string>
     <key>objects</key>
     <array>
         <dict>
@@ -258,7 +260,7 @@ The Dark Knight of Chrome search tools - a lightning-fast Alfred workflow that p
         </dict>
     </dict>
     <key>version</key>
-    <string>1.0.0</string>
+    <integer>1</integer>
     <key>webaddress</key>
     <string>https://github.com/jguice/tabman</string>
     <key>files</key>


### PR DESCRIPTION
Adds version information to Alfred workflow UI by:

- Adding version key to info.plist
- Updating release workflow to maintain version during releases

This allows users to see which version of Tabman they're running directly in Alfred's workflow interface.

### Testing
- [ ] Verify version shows up in Alfred workflow UI
- [ ] Confirm release workflow updates version correctly
- [ ] Check version format matches semantic versioning