### PR TITLE
fix: display correct version in Alfred UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,14 @@ jobs:
           NEXT_VERSION=$(npx semantic-release --dry-run | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' || echo '')
           
           if [ ! -z "$NEXT_VERSION" ]; then
-            # Create a temporary file with the version update
+            # Update version in info.plist
             awk -v ver="$NEXT_VERSION" '
               /<key>version<\/key>/ {
                 print $0
                 getline
-                sub(/>.*</, ">" ver "<")
+                if ($0 ~ /<(integer|string)>/) {
+                  sub(/>.*</, ">" ver "<")
+                }
               }
               { print }
             ' info.plist > info.plist.tmp && mv info.plist.tmp info.plist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get the next version that semantic-release will create
-          NEXT_VERSION=$(npx semantic-release --dry-run | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' || echo '')
+          NEXT_VERSION=$(npx semantic-release --dry-run | grep "The next release version is" | sed -E 's/.*is ([0-9]+\.[0-9]+\.[0-9]+).*/\1/' || echo '')
           
           if [ ! -z "$NEXT_VERSION" ]; then
             # Update version in info.plist

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ Icon
 *.alfredworkflow
 workflow/
 
+# Build artifacts
+Tabman.alfredworkflow
+workflow/
+
 # Node.js (if needed in future)
 node_modules/
 npm-debug.log*

--- a/info.plist
+++ b/info.plist
@@ -56,8 +56,6 @@
     <false/>
     <key>name</key>
     <string>Tabman</string>
-    <key>version</key>
-    <string>1.0.1</string>
     <key>objects</key>
     <array>
         <dict>
@@ -260,7 +258,7 @@ The Dark Knight of Chrome search tools - a lightning-fast Alfred workflow that p
         </dict>
     </dict>
     <key>version</key>
-    <integer>1</integer>
+    <string>1.1.0</string>
     <key>webaddress</key>
     <string>https://github.com/jguice/tabman</string>
     <key>files</key>


### PR DESCRIPTION
Fixes version display in Alfred workflow UI by:

- Using Alfred's version element as string instead of integer
- Removing custom releaseversion key
- Updating release workflow to handle version updates
- Removing workflow build artifacts from git

This ensures the semantic version number appears correctly in Alfred's workflow interface.

### Testing
- [x] Verify version shows up correctly in Alfred workflow UI
- [x] Confirm release workflow updates version correctly
- [x] Check workflow artifacts are properly ignored